### PR TITLE
Fix Resistor Bugs

### DIFF
--- a/src/Resistor/Resistor.ts
+++ b/src/Resistor/Resistor.ts
@@ -19,6 +19,8 @@ class Resistor {
     [ Resistor.BLACK, Resistor.BROWN, Resistor.RED, Resistor.ORANGE, Resistor.YELLOW, Resistor.GREEN,
       Resistor.BLUE, Resistor.VIOLET, Resistor.GREY, Resistor.WHITE, Resistor.GOLD, Resistor.SILVER ];
 
+  public static readonly INVALID_RESISTOR = -1;
+
   /** getValue assumes there is no tolerance band, as tolerance is not part of the value calculation */
   public static getValue(colors: ResistorColorEntry[]) {
     if (colors.length < 3 || colors.length > 4) {
@@ -33,7 +35,7 @@ class Resistor {
     for (let i = 0; i < (colors.length - 1); ++i) {
       const currentColor = colors[i];
       if (currentColor.value === undefined) {
-        throw new Error('Invalid value color');
+        return Resistor.INVALID_RESISTOR;
       }
       value *= 10;
       value += currentColor.value;

--- a/src/Resistor/ResistorColorEntry.ts
+++ b/src/Resistor/ResistorColorEntry.ts
@@ -25,14 +25,14 @@ class ResistorColorEntry {
   }
 
   public hasTolerance() {
-    return (this.value !== undefined);
+    return (this.toleranceInPercent !== undefined);
   }
 
   public getDisplayTolerance() {
     if (this.toleranceInPercent === undefined) {
       return '';
     }
-    return `&plusmn; ${this.toleranceInPercent}%`;
+    return `${this.toleranceInPercent}%`;
   }
 }
 

--- a/test/resistor.js
+++ b/test/resistor.js
@@ -25,8 +25,18 @@ describe('Resistor', function () {
   });
 
   it('Invalid Resistors', function () {
-    assert.throws(() => Resistor.getValue([Resistor.GOLD, Resistor.RED, Resistor.RED]), /Invalid value color/);
-    assert.throws(() => Resistor.getValue([Resistor.ORANGE, Resistor.RED, Resistor.SILVER, Resistor.YELLOW]), /Invalid value color/);
+    assert.strictEqual(Resistor.getValue([Resistor.GOLD, Resistor.RED, Resistor.RED]), Resistor.INVALID_RESISTOR);
+    assert.strictEqual(Resistor.getValue([Resistor.ORANGE, Resistor.RED, Resistor.SILVER, Resistor.YELLOW]), Resistor.INVALID_RESISTOR);
+  });
+
+  it('Tolerance', function () {
+    assert.strictEqual(Resistor.GOLD.hasTolerance(), true);
+    assert.strictEqual(Resistor.BLACK.hasTolerance(), false);
+  });
+
+  it('Value', function () {
+    assert.strictEqual(Resistor.GOLD.hasValue(), false);
+    assert.strictEqual(Resistor.BLACK.hasValue(), true);
   });
 
   it('Too Short', function () {
@@ -40,6 +50,6 @@ describe('Resistor', function () {
   });
 
   it('Tolerance', function () {
-    assert.strictEqual(Resistor.GOLD.getDisplayTolerance(), '&plusmn; 5%');
+    assert.strictEqual(Resistor.GOLD.getDisplayTolerance(), '5%');
   });
 });


### PR DESCRIPTION
Fixes #48.
Fixes #49.

Also removes the +/- from the tolerance output since that was getting escaped in the frontend and wasn't useful.