### PR TITLE
Add xmlns to the svg tag

### DIFF
--- a/src/Common/InlineSvg.ts
+++ b/src/Common/InlineSvg.ts
@@ -10,7 +10,8 @@ class InlineSvg {
   }
 
   public render(width: number): string {
-    return `<svg width="${width}" viewBox="0 0 ${this.viewBoxWidth} ${this.viewBoxHeight}">${this.inlineSvg}</svg>`;
+    // tslint:disable-next-line:max-line-length
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" viewBox="0 0 ${this.viewBoxWidth} ${this.viewBoxHeight}">${this.inlineSvg}</svg>`;
   }
 }
 


### PR DESCRIPTION
This allows the result to be used as part of a [data URI](https://css-tricks.com/probably-dont-base64-svg/)