### PR TITLE
Advanced Morse Transforms

### DIFF
--- a/src/Morse/MorseCharacter.ts
+++ b/src/Morse/MorseCharacter.ts
@@ -6,14 +6,18 @@ import {MorseEncoding} from './MorseEncoding';
 const MORSE_BITMASK = MorseEncoding.Dot | MorseEncoding.Dash;
 
 export class MorseCharacter extends EncodingCharacterBase<MorseEncoding> {
+  static readonly DOT: string = '.';
+  static readonly DASH: string = '-';
+  static readonly DIVIDER: string = '/';
+
   static toMorseString(encoding: MorseEncoding) {
     let morseChars = '';
 
     while (encoding !== MorseEncoding.None) {
       if ((encoding & MORSE_BITMASK) === MorseEncoding.Dot) {
-        morseChars += '.';
+        morseChars += MorseCharacter.DOT;
       } else if ((encoding & MORSE_BITMASK) === MorseEncoding.Dash) {
-        morseChars += '-';
+        morseChars += MorseCharacter.DASH;
       } else {
         throw new Error('Invalid morse bits');
       }
@@ -29,9 +33,9 @@ export class MorseCharacter extends EncodingCharacterBase<MorseEncoding> {
 
     for (let i = morse.length - 1; i >= 0; i--) {
       const ch = morse[i];
-      if (ch === '.') {
+      if (ch === MorseCharacter.DOT) {
         bits |= MorseEncoding.Dot;
-      } else if (ch === '-') {
+      } else if (ch === MorseCharacter.DASH) {
         bits |= MorseEncoding.Dash;
       } else {
         throw new Error('Invalid morse character');
@@ -69,13 +73,22 @@ export class MorseCharacter extends EncodingCharacterBase<MorseEncoding> {
   }
 
   dot() {
-    this._morse += '.';
+    this._morse += MorseCharacter.DOT;
     this.invalidateLookup();
   }
 
   dash() {
-    this._morse += '-';
+    this._morse += MorseCharacter.DASH;
     this.invalidateLookup();
+  }
+
+  invertDotsAndDashes() {
+    // Replace dots with a placeholder, dashes with dots, then placeholders with dashes
+    this._morse = this._morse.replace(/\./g, 'A').replace(/-/g, MorseCharacter.DOT).replace(/A/g, MorseCharacter.DASH);
+  }
+
+  reverse() {
+    this._morse = this._morse.split('').reverse().join('');
   }
 
   protected onClear() {

--- a/src/Morse/MorseString.ts
+++ b/src/Morse/MorseString.ts
@@ -1,0 +1,45 @@
+import {MorseCharacter} from './MorseCharacter';
+
+// MorseString represents a string of multiple morse characters.  It allows for a longer representation
+// to be converted to a single string and allows for sentence-level transforms such as reversing
+// the order of tokens.
+export class MorseString {
+  constructor(morse = '', divider = MorseCharacter.DIVIDER) {
+    const morseCharStrings = morse.split(divider);
+    // Discard any empty characters (caused by trailing separator)
+    this._chars = morseCharStrings.filter(mcs => mcs.length > 0).map(mcs => new MorseCharacter(mcs));
+  }
+
+  // reverse reverses the order of all tokens in the string (including separators), such as would be
+  // the case if you were reading the data for a puzzle backwards.
+  reverse(): MorseString {
+    for (const c of this._chars) {
+      c.reverse();
+    }
+    this._chars = this._chars.reverse();
+    return this;
+  }
+
+  // invertDotsAndDashes switches all dots and dashes in the input, such as would be the case if
+  // you had two ambiguous symbols for dot/dash and selected the wrong mapping.
+  invertDotsAndDashes(): MorseString {
+    for (const c of this._chars) {
+      c.invertDotsAndDashes();
+    }
+    return this;
+  }
+
+  toString(): string {
+    let s = '';
+    for (const c of this._chars) {
+      s += (c.toString() || '?');
+    }
+    return s;
+  }
+
+  get chars() {
+    return this._chars;
+  }
+
+  protected _chars: MorseCharacter[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {SignificantFigures} from './Conversion/SignificantFigures';
 export {StringAutoConvert} from './Conversion/StringAutoConvert';
 export {MorseCharacter} from './Morse/MorseCharacter';
 export {MorseEncoding} from './Morse/MorseEncoding';
+export {MorseString} from './Morse/MorseString';
 export {NatoCharacter} from './Nato/NatoCharacter';
 export {NatoData} from './Nato/NatoData';
 export {NavalFlags} from './NavalFlags/NavalFlags';

--- a/test/morse.js
+++ b/test/morse.js
@@ -1,7 +1,7 @@
 /* global describe, it */
 
 const assert = require('assert');
-const { MorseCharacter } = require('../');
+const { MorseCharacter, MorseString } = require('../');
 
 describe('Morse', function () {
   describe('Character', function () {
@@ -144,6 +144,39 @@ describe('Morse', function () {
 
       ch.dot();
       assert.strictEqual(ch.valid(), false);
+    });
+  });
+
+  describe('String', function () {
+    it('constructor - Basic', function () {
+      assert.strictEqual(new MorseString('.').toString(), 'E');
+      assert.strictEqual(new MorseString('.../---/...').toString(), 'SOS');
+
+      assert.strictEqual(new MorseString('./.-/--./-').toString(), 'EAGT');
+    });
+
+    it('Invert dots/dashes', function() {
+      // Becomes ---/.../---
+      assert.strictEqual(new MorseString('.../---/...').invertDotsAndDashes().toString(), 'OSO');
+
+      // Becomes -/-./..-/.
+      assert.strictEqual(new MorseString('./.-/--./-').invertDotsAndDashes().toString(), 'TNUE');
+
+      // Should undo itself if repeated
+      assert.strictEqual(new MorseString('./.-/--./-').invertDotsAndDashes().invertDotsAndDashes().toString(), 'EAGT');
+    });
+
+    it('Reverse', function() {
+      // Becomes -/.--/-./.
+      assert.strictEqual(new MorseString('./.-/--./-').reverse().toString(), 'TWNE');
+
+      // Should undo itself if repeated
+      assert.strictEqual(new MorseString('./.-/--./-').reverse().reverse().toString(), 'EAGT');
+    });
+
+    it('Chaining', function() {
+      assert.strictEqual(new MorseString('./.-/--./-').invertDotsAndDashes().reverse().toString(), 'EDAT');
+      assert.strictEqual(new MorseString('./.-/--./-').reverse().invertDotsAndDashes().toString(), 'EDAT');
     });
   });
 });


### PR DESCRIPTION
Add ability to invert dots/dashes, map a string containing multiple morse characters, and reverse the order of tokens to account for mistakes reading puzzle data.

For an example of how to consume the new APIs, see https://github.com/beckbria/puzztool/commit/13d98cd08c1d7780d010cc953c1078376240335b

I'm still tweaking the UI, but for a basic example:
![image](https://user-images.githubusercontent.com/2019044/50519609-cc8b7680-0a89-11e9-9ab9-91f2ff698b61.png)
