### PR TITLE
Drop node/11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - libstdc++-4.9-dev
+branches:
+  only:
+  - master
 env:
   global:
-  - NVS_VERSION=1.4.2
+  - NVS_VERSION=1.5.2
   matrix:
   - NODEJS_VERSION=node/8
   - NODEJS_VERSION=node/10
-  - NODEJS_VERSION=node/11
   - NODEJS_VERSION=node/12
   - NODEJS_VERSION=chakracore/10
 before_install:
@@ -28,11 +30,3 @@ install:
 - npm --version
 # Install the application's NPM dependencies.
 - npm install
-deploy:
-  provider: npm
-  email: $NPM_EMAIL
-  api_key: $NPM_TOKEN
-  skip_cleanup: true
-  on:
-    tags: true
-    condition: $NODEJS_VERSION = node/10

--- a/package-lock.json
+++ b/package-lock.json
@@ -652,7 +652,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -802,7 +802,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -832,7 +832,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -1098,7 +1098,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },


### PR DESCRIPTION
Support ended at the beginning of June.

Also upgraded NVS to v1.5.2, limited to only building master, and removed the deployment step since it doesn't work with 2fa anyway.